### PR TITLE
Fix location info so importing to google calendar, then using google maps works

### DIFF
--- a/buildings.txt
+++ b/buildings.txt
@@ -1,0 +1,270 @@
+Arrival Point &amp; Security Lodge
+Barnes Wallis
+Echo
+Echo Street Garages
+Echoes Day Nursery
+Fairfield Hall
+Ferranti
+George Begg
+John Garside
+Lambert Hall
+Moffat
+Multi-storey Car Park (Charles St)
+Paper Science
+Pariser
+Renold
+Sackville
+Sackville Street
+Staff House
+The Arches Incubator Unit 28
+The Arches Incubator Unit 29
+The Arches Incubator Unit 30
+The Arches Unit 16
+The Mill
+The Morton Laboratory
+Weston Hall
+Wright Robinson Hall
+176 Waterloo Place
+178 Waterloo Place
+180 Waterloo Place
+182 Waterloo Place
+184 Waterloo Place
+186 Waterloo Place
+188 Waterloo Place
+A V Hill
+Academy
+Alan Turing
+Arthur Lewis
+Beyer
+Bowden Court Court 2
+Bowden Court Court 3
+Carys Bannister
+Central Plant
+Chemistry
+Christie
+Core Technology Facility
+Coupland 1
+Coupland 3
+Denmark Road
+Dixon Stores
+Dover
+Dover Street
+Dryden
+Dryden Street Nursery
+Ellen Wilkinson
+George Kenyon
+Grosvenor Place
+Grosvenor
+Grosvenor Street
+Horniman House
+Humanities Bridgeford
+Humanities Bridgeford Street
+Information Technology
+Jean McFarlane
+John Owens
+John Rylands Library &amp; Muriel Stott Centre
+Kilburn
+Manchester Aquatics Centre
+Manchester Business School East
+Manchester Business School West
+Manchester Incubator
+Manchester Museum
+Mansfield Cooper
+Martin Harris Centre
+Martin Harris Electro Acoustic Studio
+Materials Science Centre
+McDougall Sports Centre
+Michael Smith
+Multi-storey Car Park B
+Multi-storey Car Park D
+Muriel Stott Centre
+Muslim Prayer Hall South
+Oddfellows Hall
+Pharmacy
+Precinct Centre 1 (Shops, Harold Hankins, Devonshire)
+Precinct Centre 2 (Crawford House and Federal School Theatre
+Prospect House
+Ronson Hall
+Roscoe
+Rutherford
+Samuel Alexander
+Schunck
+Schuster
+Simon
+St Peters House
+Stephen Joseph Studio
+Stopford
+Students Union
+Sugden Sports Centre
+Turner Dental School
+University Place
+University Place - Energy Centre
+Vaughan House
+Whitworth Art Gallery
+Whitworth Hall
+Whitworth Park - Aberdeen House
+Whitworth Park - Acomb House
+Whitworth Park - Burleigh House
+Whitworth Park - Derby House
+Whitworth Park - Dilworth House
+Whitworth Park - Garstang House
+Whitworth Park - Grove House/Amenity Block
+Whitworth Park - Leamington House
+Whitworth Park - Security Lodge
+Whitworth Park - Store
+Whitworth Park - Thorncliffe House
+Whitworth Park - Vehicle Store
+William Kay House
+Williamson
+Zochonis
+Dalton-Ellis Hall - Dining &amp; Garage Block
+Dalton-Ellis Hall - Eaglesfield
+Dalton-Ellis Hall - Ewings
+Dalton-Ellis Hall - Fiddes
+Dalton-Ellis Hall - Graham
+Dalton-Ellis Hall - Main Hall &amp; Reception
+Dalton-Ellis Hall - Nield Wing
+Dalton-Ellis Hall - Pankhurst 1
+Dalton-Ellis Hall - Pankhurst 2
+Dalton-Ellis Hall - Sunnyside
+Dalton-Ellis Hall - Sutherland
+Dalton-Ellis Hall - The Laurence Kendal Court
+Hulme Hall - Bikeshed
+Hulme Hall - Birley (Block F)
+Hulme Hall - Burkhardt
+Hulme Hall - Chapel
+Hulme Hall - Christie (Block C)
+Hulme Hall - Dining Room &amp; Reception
+Hulme Hall - Greenwood (Block D)
+Hulme Hall - Gymnasium &amp; Squash Block
+Hulme Hall - Houldsworth (Block H)
+Hulme Hall - John Hartshorne Centre
+Hulme Hall - Oaklands (Block A)
+Hulme Hall - Park House
+Hulme Hall - Plymouth (Block E)
+Hulme Hall - Staff Accommodation
+Hulme Hall - Wardens House
+Hulme Hall - Wardens Shed
+Opal Gardens - Brotherton Court
+Opal Gardens - Kilburn Court
+Opal Gardens - Philips Court
+Opal Gardens - Williams Court
+St Anselm Hall - Bikeshed
+St Anselm Hall - Canterbury Court, General
+St Anselm Hall - Canterbury Court, Bikeshed 1
+St Anselm Hall - Canterbury Court, Bikeshed 2
+St Anselm Hall - Chapel
+St Anselm Hall - Dewar
+St Anselm Hall - Dining Hall
+St Anselm Hall - Manor
+St Anselm Hall - Schuster
+St Anselm Hall - Squash Court
+St Anselm Hall - The Lodge
+St Anselm Hall - Workshop &amp; Garages
+St Gabriel Hall - Main
+St Gabriels Hall - Boilerhouse/Store
+St Gabriels Hall - Woodthorpe
+Allen Hall - Cycle Shed
+Allen Hall - Garages
+Allen Hall - Main Block &amp; Reception
+Allen Hall - More
+Allen Hall - Newman
+Allen Hall - Teilhard
+Armitage Centre
+Ashburne Hall - Ashgate Lodge
+Ashburne Hall - Behrens House
+Ashburne Hall - Centre &amp; Reception
+Ashburne Hall - Sheavyn House
+Ashburne Hall - The Cottage
+Ashburne Hall - Uttley Hall
+Botany Experimental Grounds - Alpine House
+Botany Experimental Grounds - Boilerhouse
+Botany Experimental Grounds - Crypto Cubicles 1-12
+Botany Experimental Grounds - Garage Store
+Botany Experimental Grounds - Glasshouse 6-8
+Botany Experimental Grounds - Glasshouse 9
+Botany Experimental Grounds - Glasshouse Cubicles 14-16
+Botany Experimental Grounds - Moss House
+Botany Experimental Grounds - Offices
+Botany Experimental Grounds - Old Aphid Cubicle 13
+Botany Experimental Grounds - Old Lab Stores
+Botany Experimental Grounds - Potting Shed/Store
+Botany Experimental Grounds - Range Glasshouse 1-5
+Botany Experimental Grounds - Solvent Store
+Botany Experimental Grounds - Teaching Rooms
+Chancellors Conference Centre
+Chancellors Sub Station
+Firs - Garage Store
+Firs - Plant &amp; Machinery Stores
+Firs - Site Maintenance Offices &amp; Stores
+Firs - Squash Courts 1-2
+Firs - Squash Courts 3-4
+Firs Pavillion
+Firs Security Lodge
+Firs Villa
+Linton House
+Oak House - Beech Court
+Oak House - Bikeshed
+Oak House - Carill House
+Oak House - Chestnut Court
+Oak House - Holly Court
+Oak House - Maple Court
+Oak House - Squirrels Bar
+Oak House - Sycamore Court
+Owens Park - Bar Lounge and Hall
+Owens Park - Bikeshed
+Owens Park - Central Administration Block
+Owens Park - Green Court
+Owens Park - Little Court
+Owens Park - Mall Block
+Owens Park - The Limes
+Owens Park - The Limes Garages &amp; Stores
+Owens Park - The Limes Stores
+Owens Park - Tower Block
+Owens Park - Tree Court
+Richmond Park - Poplar Court, Flats 17-24
+Richmond Park - Poplar Court, Flats 1-8
+Richmond Park - Poplar Court, Flats 25-32
+Richmond Park - Poplar Court, Flats 9-16
+Richmond Park - Reception
+Richmond Park - Willow Court, Flats 17-24
+Richmond Park - Willow Court, Flats 1-8
+Richmond Park - Willow Court, Flats 25-32
+Richmond Park - Willow Court, Flats 9-16
+Woolton Hall - Bikeshed
+Woolton Hall - Bungalow
+Woolton Hall - Cavendish House
+Woolton Hall - Garages
+Woolton Hall - Lindsay House
+Woolton Hall - Main
+Woolton Hall - Morley House
+Woolton Hall - Spencer House
+Woolton Hall - Stores
+Botany Experimental Ground, Store 2
+Bridge Farm - Farm House
+Cheshire Hunt Farm
+Jodrell Bank - Boiler House (Workshops)
+Jodrell Bank - Control
+Jodrell Bank - Cryogenics Workshop
+Jodrell Bank - Development Lab
+Jodrell Bank - Discovery Centre
+Jodrell Bank - Dormitory Block
+Jodrell Bank - Electrical Workshop
+Jodrell Bank - Environmental Discovery Centre
+Jodrell Bank - Killian Shed
+Jodrell Bank - Lovell Telescope
+Jodrell Bank - Mark II Telescope
+Jodrell Bank - Mechanical Workshop
+Jodrell Bank - MSC Link Tower
+Jodrell Bank - No 1 Cottage
+Jodrell Bank - No 2 Cottage
+Jodrell Bank - Old Moon Hut Store
+Jodrell Bank - Old Observatory Store
+Jodrell Bank - Old Radiant
+Jodrell Bank - Park Royal
+Jodrell Bank - SKA
+Jodrell Bank - Space Pavillion
+Jodrell Bank - Telescope Workshop
+Jodrell Bank - Vehicle Shed
+Jodrell Bank - Wardle Hut
+Jodrell Bank - Wood/Metal Store

--- a/examiCal.php
+++ b/examiCal.php
@@ -89,6 +89,15 @@ if(!empty($_POST)) {
 
     $start = strtotime($data[$mapping['date']]." ".$data[$mapping['start']]);
     $end = strtotime($data[$mapping['date']]." ".$data[$mapping['end']]);
+    
+    // List of buildings at Uom, all campuses as array.
+    $lines = file("buildings.txt", FILE_IGNORE_NEW_LINES);
+    // Loop through all building names, try to find one that matches
+    $fixedLocation=$data[$mapping['location']];
+    foreach ($lines as $value)
+    if (strpos($data[$mapping['location']], $value) !== FALSE) {
+      $fixedLocation=$value . ", University of Manchester";
+    }
 
     print("BEGIN:VEVENT\r\n");
     print("DTSTART:".date("Ymd", $start)."T".date("His", $start)."\r\n");
@@ -100,7 +109,7 @@ if(!empty($_POST)) {
                         ."\\nStart: ".$data[$mapping['start']]
                         ."\\nEnd: ".$data[$mapping['end']]
                         ."\\n\\nRaw\\n". str_replace("\t", " - ", $row)."\r\n");
-    print("LOCATION:".$data[$mapping['location']]."\r\n");
+    print("LOCATION:".$fixedLocation."\r\n");
     print("END:VEVENT\r\n");
 
   }

--- a/get-buildings-list.sh
+++ b/get-buildings-list.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+ids=(29 10 13 06 09)
+n_elements=${#ids[@]}
+let "max_index=$n_elements - 1"
+
+if [ -e source ]
+then 
+  :
+else
+  mkdir "source"
+fi
+if [ -e "source/list1" ]
+then
+  rm source/*
+fi
+# Dowload buildings list
+for i in `seq 0 $max_index`;
+do
+  curl "http://man-estates-fs5.ds.man.ac.uk/PSU/Building_Information/Building_List.aspx?CampID=S${ids[i]}" > "source/list$i";
+done
+# If we have correct permissions...
+if [ -e "source" ]
+then
+  cd source
+  if [ -e "temp" ]
+  then
+    rm "temp"
+  fi
+  # Get needed lines
+  for i in `seq 0 $max_index`;
+  do
+    grep "href=\"Building" "list$i" >> "temp"
+  done
+
+  end="</font></td>"
+  num=`cat <<< $end | wc -c`
+  let "num=$num+1" 
+  if [ -e "../buildings.txt" ]
+  then
+    echo "buildings.txt already exists... exiting"
+    exit 0;
+  fi
+  # Convert line to just building name
+  while read line
+  do
+    # Remove a load of stuff from the start
+    thing=`cut -d "\"" -f 9 <<< "$line"`
+    # Select everything but first character '>'
+    thing=`cut -c 2- <<< "$thing"`
+    # Remove string $end from thing.
+    thing=`rev <<< $thing | cut -c $num- | rev`
+    # Remove the word "building, as on mymanchester it doesn't add building; ie: Simon not Simon Building"
+    thing=${thing%Building*}
+    thing=${thing%building*}
+    # Sackville street building is abbreviated on mymanchester.
+    nostreet=${thing%Street*}
+    if [ "$thing" == "$nostreet" ]
+    then
+      :
+    else
+      echo "$nostreet" >> "../buildings.txt"    
+    fi
+    echo $thing >> "../buildings.txt"
+  done < "temp"
+  # Clean up
+  cd ../
+  sed -i -e 's/^[ \t]*//' -e 's/[ \t]*$//' buildings.txt
+  cat buildings.txt | uniq > temp
+  cat temp > buildings.txt 
+  rm temp
+  rm source/*
+  rmdir source
+else
+  echo "source folder doesnt exist, need write permissions."
+fi


### PR DESCRIPTION
Strip location info to just building name, ie; "Simon Theatre A" becomes "Simon",
then append ", University of Manchester" so if you try to open the event in google maps, the map opens at the correct building and not at some place in America, or just return no result...  (as it did previously for Simon Theatre A and one or two others)
